### PR TITLE
Fix loop initialization in project07 variants

### DIFF
--- a/project07.8.diag.blk.c
+++ b/project07.8.diag.blk.c
@@ -44,7 +44,7 @@ int main(void)
 
 				yhts[xrnd[i]] = 1;
 				yvar[i] = 0;
-				for (k-0; k<100; k++) {
+                                for (k=0; k<100; k++) {
 					ymu[i] = ymu[i]+(float)yhts[k]/100;
 					ftemp = ((float)yhts[k] - ymu[i]);
 					ftemp = ftemp * ftemp;

--- a/project07.8.diag.plus.c
+++ b/project07.8.diag.plus.c
@@ -44,7 +44,7 @@ int main(void)
 
 				yhts[xrnd[i]] = 1;
 				yvar[i] = 0;
-				for (k-0; k<100; k++) {
+                                for (k=0; k<100; k++) {
 					ymu[i] = ymu[i]+(float)yhts[k]/100;
 					ftemp = ((float)yhts[k] - ymu[i]);
 					ftemp = ftemp * ftemp;

--- a/project07.c
+++ b/project07.c
@@ -49,7 +49,7 @@ int main(void)
 
 				yhts[xrnd[i]] = 1;
 				yvar[i] = 0;
-				for (k-0; k<100; k++) {
+                                for (k=0; k<100; k++) {
 					ymu[i] = ymu[i]+(float)yhts[k]/100;
 					ftemp = ((float)yhts[k] - ymu[i]);
 					ftemp = ftemp * ftemp;


### PR DESCRIPTION
## Summary
- start loops from zero in project07 implementations
- rebuild to verify compilation

## Testing
- `gcc project07.c -lm -lncurses -o project07`
- `gcc project07.8.diag.blk.c -lm -lncurses -o project07.8.diag.blk`
- `gcc project07.8.diag.plus.c -lm -lncurses -o project07.8.diag.plus`

------
https://chatgpt.com/codex/tasks/task_e_6844af6687d88327b2d54701ee62b932