### PR TITLE
Add compile test script

### DIFF
--- a/.github/workflows/compile-test.yml
+++ b/.github/workflows/compile-test.yml
@@ -1,0 +1,15 @@
+name: Compile Test
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y gcc libncurses5-dev
+      - name: Run test script
+        run: bash ./test_compile.sh

--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ HOW TO COMPILE:
   
 (This assumes gcc and the ncurses library is installed. For ubuntu, a simple "sudo apt-get install gcc libncurses5" should do.)
 
+TESTING THE SOURCE CODE:
+
+* Run `./test_compile.sh` to compile every `project*.c` file. The script stops
+  if any of the files fail to build.
+
 
 
 

--- a/test_compile.sh
+++ b/test_compile.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+for src in project*.c; do
+  [ -e "$src" ] || continue
+  echo "Compiling $src"
+  gcc "$src" -lm -lncurses -o /tmp/test_bin
+done
+
+echo "All files compiled successfully."


### PR DESCRIPTION
## Summary
- add `test_compile.sh` for building all project sources
- document test script usage in `README.md`
- run the script on pushes using a GitHub Actions workflow

## Testing
- `./test_compile.sh`

------
https://chatgpt.com/codex/tasks/task_e_6844b078b86083278dd560aebb2a43d4